### PR TITLE
README: fix links to SDKMAN

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Install and execute Maven Central packages or kotlin scripts just like any other
 
 ## Installation
 
-### (Recommended) [SDKMAN](sdkman.io)
+### (Recommended) [SDKMAN](https://sdkman.io)
 
 ```shell
 sdk install ktx
@@ -19,7 +19,7 @@ curl https://raw.githubusercontent.com/mpetuska/ktx/master/scripts/install.sh | 
 
 ## Uninstallation
 
-### (Recommended) [SDKMAN](sdkman.io)
+### (Recommended) [SDKMAN](https://sdkman.io)
 
 ```shell
 # Check which versions are installed


### PR DESCRIPTION
Without this change, GitHub assumes it's about a file in the root of the repo: `sdkman.io`.